### PR TITLE
Anthony Whitehead tech test

### DIFF
--- a/.claude/laravel-php-guidelines.md
+++ b/.claude/laravel-php-guidelines.md
@@ -1,0 +1,242 @@
+# Laravel & PHP Guidelines for AI Code Assistants
+
+This file contains Laravel and PHP coding standards optimized for AI code assistants like Claude Code, GitHub Copilot, and Cursor. These guidelines are derived from Spatie's comprehensive Laravel & PHP standards.
+
+## Core Laravel Principle
+
+**Follow Laravel conventions first.** If Laravel has a documented way to do something, use it. Only deviate when you have a clear justification.
+
+## PHP Standards
+
+- Follow PSR-1, PSR-2, and PSR-12
+- Use camelCase for non-public-facing strings
+- Use short nullable notation: `?string` not `string|null`
+- Always specify `void` return types when methods return nothing
+
+## Class Structure
+- Use typed properties, not docblocks:
+- Constructor property promotion when all properties can be promoted:
+- One trait per line:
+
+## Type Declarations & Docblocks
+- Use typed properties over docblocks
+- Specify return types including `void`
+- Use short nullable syntax: `?Type` not `Type|null`
+- Document iterables with generics:
+  ```php
+  /** @return Collection<int, User> */
+  public function getUsers(): Collection
+  ```
+
+### Docblock Rules
+- Don't use docblocks for fully type-hinted methods (unless description needed)
+- **Always import classnames in docblocks** - never use fully qualified names:
+  ```php
+  use \Spatie\Url\Url;
+  /** @return Url */
+  ```
+- Use one-line docblocks when possible: `/** @var string */`
+- Most common type should be first in multi-type docblocks:
+  ```php
+  /** @var Collection|SomeWeirdVendor\Collection */
+  ```
+- If one parameter needs docblock, add docblocks for all parameters
+- For iterables, always specify key and value types:
+  ```php
+  /**
+   * @param array<int, MyObject> $myArray
+   * @param int $typedArgument 
+   */
+  function someFunction(array $myArray, int $typedArgument) {}
+  ```
+- Use array shape notation for fixed keys, put each key on it's own line:
+  ```php
+  /** @return array{
+     first: SomeClass, 
+     second: SomeClass
+  } */
+  ```
+
+## Control Flow
+- **Happy path last**: Handle error conditions first, success case last
+- **Avoid else**: Use early returns instead of nested conditions  
+- **Separate conditions**: Prefer multiple if statements over compound conditions
+- **Always use curly brackets** even for single statements
+- **Ternary operators**: Each part on own line unless very short
+
+```php
+// Happy path last
+if (! $user) {
+    return null;
+}
+
+if (! $user->isActive()) {
+    return null;
+}
+
+// Process active user...
+
+// Short ternary
+$name = $isFoo ? 'foo' : 'bar';
+
+// Multi-line ternary
+$result = $object instanceof Model ?
+    $object->name :
+    'A default value';
+
+// Ternary instead of else
+$condition
+    ? $this->doSomething()
+    : $this->doSomethingElse();
+```
+
+## Laravel Conventions
+
+### Routes
+- URLs: kebab-case (`/open-source`)
+- Route names: camelCase (`->name('openSource')`)
+- Parameters: camelCase (`{userId}`)
+- Use tuple notation: `[Controller::class, 'method']`
+
+### Controllers
+- Plural resource names (`PostsController`)
+- Stick to CRUD methods (`index`, `create`, `store`, `show`, `edit`, `update`, `destroy`)
+- Extract new controllers for non-CRUD actions
+
+### Configuration
+- Files: kebab-case (`pdf-generator.php`)
+- Keys: snake_case (`chrome_path`)
+- Add service configs to `config/services.php`, don't create new files
+- Use `config()` helper, avoid `env()` outside config files
+
+### Artisan Commands
+- Names: kebab-case (`delete-old-records`)
+- Always provide feedback (`$this->comment('All ok!')`)
+- Show progress for loops, summary at end
+- Put output BEFORE processing item (easier debugging):
+  ```php
+  $items->each(function(Item $item) {
+      $this->info("Processing item id `{$item->id}`...");
+      $this->processItem($item);
+  });
+  
+  $this->comment("Processed {$items->count()} items.");
+  ```
+
+## Strings & Formatting
+
+- **String interpolation** over concatenation:
+
+## Enums
+
+- Use PascalCase for enum values:
+
+## Comments
+
+- **Avoid comments** - write expressive code instead
+- When needed, use proper formatting:
+  ```php
+  // Single line with space after //
+  
+  /*
+   * Multi-line blocks start with single *
+   */
+  ```
+- Refactor comments into descriptive function names
+
+## Whitespace
+
+- Add blank lines between statements for readability
+- Exception: sequences of equivalent single-line operations
+- No extra empty lines between `{}` brackets
+- Let code "breathe" - avoid cramped formatting
+
+## Validation
+
+- Use array notation for multiple rules (easier for custom rule classes):
+  ```php
+  public function rules() {
+      return [
+          'email' => ['required', 'email'],
+      ];
+  }
+  ```
+- Custom validation rules use snake_case:
+  ```php
+  Validator::extend('organisation_type', function ($attribute, $value) {
+      return OrganisationType::isValid($value);
+  });
+  ```
+
+## Blade Templates
+
+- Indent with 4 spaces
+- No spaces after control structures:
+  ```blade
+  @if($condition)
+      Something
+  @endif
+  ```
+
+## Authorization
+
+- Policies use camelCase: `Gate::define('editPost', ...)`
+- Use CRUD words, but `view` instead of `show`
+
+## Translations
+
+- Use `__()` function over `@lang`:
+
+## API Routing
+
+- Use plural resource names: `/errors`
+- Use kebab-case: `/error-occurrences`
+- Limit deep nesting for simplicity:
+  ```
+  /error-occurrences/1
+  /errors/1/occurrences
+  ```
+
+## Testing
+
+- Keep test classes in same file when possible
+- Use descriptive test method names
+- Follow the arrange-act-assert pattern
+
+## Quick Reference
+
+### Naming Conventions
+- **Classes**: PascalCase (`UserController`, `OrderStatus`)
+- **Methods/Variables**: camelCase (`getUserName`, `$firstName`)
+- **Routes**: kebab-case (`/open-source`, `/user-profile`)
+- **Config files**: kebab-case (`pdf-generator.php`)
+- **Config keys**: snake_case (`chrome_path`)
+- **Artisan commands**: kebab-case (`php artisan delete-old-records`)
+
+### File Structure
+- Controllers: plural resource name + `Controller` (`PostsController`)
+- Views: camelCase (`openSource.blade.php`)  
+- Jobs: action-based (`CreateUser`, `SendEmailNotification`)
+- Events: tense-based (`UserRegistering`, `UserRegistered`)
+- Listeners: action + `Listener` suffix (`SendInvitationMailListener`)
+- Commands: action + `Command` suffix (`PublishScheduledPostsCommand`)
+- Mailables: purpose + `Mail` suffix (`AccountActivatedMail`)
+- Resources/Transformers: plural + `Resource`/`Transformer` (`UsersResource`)
+- Enums: descriptive name, no prefix (`OrderStatus`, `BookingType`)
+
+### Migrations
+- do not write down methods in migrations, only up methods
+
+### Code Quality Reminders
+
+#### PHP
+- Use typed properties over docblocks
+- Prefer early returns over nested if/else
+- Use constructor property promotion when all properties can be promoted
+- Avoid `else` statements when possible
+- Use string interpolation over concatenation
+- Always use curly braces for control structures
+
+---
+
+*These guidelines are maintained by [Spatie](https://spatie.be/guidelines) and optimized for AI code assistants.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,10 @@ This is a Laravel + React application using Inertia.js for seamless SPA-like exp
 - Component variants using `class-variance-authority`
 - Custom UI components follow Radix + shadcn/ui patterns
 - Appearance system with light/dark mode support
+
+### Development process
+
+## Backend
+- Read .claude/laravel-php-guidelines.md and use this as reference for any laravel code
+- All backend code must be feature/unit tested
+- Your task is only complete once you have run all tests and they pass

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -21,14 +21,21 @@ class PostController extends Controller
     {
         $search = $request->get('search', '');
 
+        $page = $request->query('page', 1);
         $posts = Post::with(['user', 'comments'])
             ->when($search, fn($query) => $query->search($search))
             ->latest()
             ->paginate(10)
             ->withQueryString();
 
+        $postPaginateProp = $posts->toArray(); // To access paginate property
+        $nextPageExists = $postPaginateProp['current_page'] < $postPaginateProp['last_page'];
+
         return Inertia::render('posts/index', [
-            'posts' => $posts,
+            'posts' => Inertia::merge($posts->items()),
+            'total' => $postPaginateProp['total'],
+            'page' => $page,
+            'nextPageExists' => $nextPageExists,
             'filters' => [
                 'search' => $search,
             ],

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -16,12 +17,21 @@ class PostController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): Response
+    public function index(Request $request): Response
     {
-        $posts = Post::with(['user', 'comments'])->latest()->paginate(10);
+        $search = $request->get('search', '');
+
+        $posts = Post::with(['user', 'comments'])
+            ->when($search, fn($query) => $query->search($search))
+            ->latest()
+            ->paginate(10)
+            ->withQueryString();
 
         return Inertia::render('posts/index', [
             'posts' => $posts,
+            'filters' => [
+                'search' => $search,
+            ],
         ]);
     }
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\DestroyPostRequest;
+use App\Http\Requests\ShowPostEditRequest;
+use App\Http\Requests\StorePostRequest;
+use App\Http\Requests\UpdatePostRequest;
 use App\Models\Post;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -33,13 +36,9 @@ class PostController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(StorePostRequest $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'content' => 'required|string',
-            'category' => 'nullable|string|max:255',
-        ]);
+        $validated = $request->validated();
 
         $post = $request->user()->posts()->create($validated);
 
@@ -61,7 +60,7 @@ class PostController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Post $post): Response
+    public function edit(ShowPostEditRequest $request, Post $post): Response
     {
         return Inertia::render('posts/edit', [
             'post' => $post,
@@ -71,13 +70,9 @@ class PostController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Post $post): RedirectResponse
+    public function update(UpdatePostRequest $request, Post $post): RedirectResponse
     {
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'content' => 'required|string',
-            'category' => 'nullable|string|max:255',
-        ]);
+        $validated = $request->validated();
 
         $post->update($validated);
 
@@ -87,7 +82,7 @@ class PostController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Post $post): RedirectResponse
+    public function destroy(DestroyPostRequest $request, Post $post): RedirectResponse
     {
         $post->delete();
 

--- a/app/Http/Requests/DestroyPostRequest.php
+++ b/app/Http/Requests/DestroyPostRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DestroyPostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $post = $this->route('post');
+
+        return $post && $this->user()->can('delete', $post);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/ShowPostEditRequest.php
+++ b/app/Http/Requests/ShowPostEditRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowPostEditRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $post = $this->route('post');
+
+        return $post && $this->user()->can('update', $post);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -23,7 +23,7 @@ class StorePostRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'slug' => ['required', 'string', 'max:255', 'unique:posts'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:posts'],
             'content' => ['required', 'string'],
             'category' => ['nullable', 'string', 'max:255'],
         ];

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -23,6 +23,7 @@ class StorePostRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'unique:posts'],
             'content' => ['required', 'string'],
             'category' => ['nullable', 'string', 'max:255'],
         ];

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'category' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -23,8 +23,11 @@ class UpdatePostRequest extends FormRequest
      */
     public function rules(): array
     {
+        $post = $this->route('post');
+
         return [
             'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', 'unique:posts,slug,'.($post ? $post->id : 'NULL')],
             'content' => ['required', 'string'],
             'category' => ['nullable', 'string', 'max:255'],
         ];

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $post = $this->route('post');
+
+        return $post && $this->user()->can('update', $post);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'category' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Observers\PostObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -36,6 +37,18 @@ class Post extends Model
         return 'slug';
     }
 
+
+    /**
+     * Scope a query to search posts by term.
+     */
+    public function scopeSearch(Builder $query, string $term): Builder
+    {
+        return $query->where(function ($q) use ($term) {
+            $q->where('name', 'like', "%{$term}%")
+              ->orWhere('content', 'like', "%{$term}%")
+              ->orWhere('category', 'like', "%{$term}%");
+        });
+    }
 
     /**
      * Generate a unique slug from the given name.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 #[ObservedBy([PostObserver::class])]
 class Post extends Model
@@ -50,31 +49,6 @@ class Post extends Model
         });
     }
 
-    /**
-     * Generate a unique slug from the given name.
-     */
-    public static function generateUniqueSlug(string $name, ?int $id = null): string
-    {
-        $baseSlug = Str::slug($name);
-        $slug = $baseSlug ?: 'untitled';
-        $counter = 1;
-
-        $query = static::where('slug', $slug);
-        if ($id) {
-            $query->where('id', '!=', $id);
-        }
-
-        while ($query->exists()) {
-            $slug = "{$baseSlug}-{$counter}";
-            $counter++;
-            $query = static::where('slug', $slug);
-            if ($id) {
-                $query->where('id', '!=', $id);
-            }
-        }
-
-        return $slug;
-    }
 
     /**
      * Get the user that owns the post.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use App\Observers\PostObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
+#[ObservedBy([PostObserver::class])]
 class Post extends Model
 {
     /** @use HasFactory<\Database\Factories\PostFactory> */
@@ -33,25 +36,6 @@ class Post extends Model
         return 'slug';
     }
 
-    /**
-     * Boot the model.
-     */
-    protected static function boot(): void
-    {
-        parent::boot();
-
-        static::creating(function ($post) {
-            if (empty($post->slug)) {
-                $post->slug = static::generateUniqueSlug($post->name);
-            }
-        });
-
-        static::updating(function ($post) {
-            if ($post->isDirty('name') && empty($post->slug)) {
-                $post->slug = static::generateUniqueSlug($post->name);
-            }
-        });
-    }
 
     /**
      * Generate a unique slug from the given name.
@@ -68,7 +52,7 @@ class Post extends Model
         }
 
         while ($query->exists()) {
-            $slug = ($baseSlug ?: 'untitled').'-'.$counter;
+            $slug = "{$baseSlug}-{$counter}";
             $counter++;
             $query = static::where('slug', $slug);
             if ($id) {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class Post extends Model
 {
@@ -19,9 +20,64 @@ class Post extends Model
      */
     protected $fillable = [
         'name',
+        'slug',
         'content',
         'category',
     ];
+
+    /**
+     * Get the route key for the model.
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function ($post) {
+            if (empty($post->slug)) {
+                $post->slug = static::generateUniqueSlug($post->name);
+            }
+        });
+
+        static::updating(function ($post) {
+            if ($post->isDirty('name') && empty($post->slug)) {
+                $post->slug = static::generateUniqueSlug($post->name);
+            }
+        });
+    }
+
+    /**
+     * Generate a unique slug from the given name.
+     */
+    public static function generateUniqueSlug(string $name, ?int $id = null): string
+    {
+        $baseSlug = Str::slug($name);
+        $slug = $baseSlug ?: 'untitled';
+        $counter = 1;
+
+        $query = static::where('slug', $slug);
+        if ($id) {
+            $query->where('id', '!=', $id);
+        }
+
+        while ($query->exists()) {
+            $slug = ($baseSlug ?: 'untitled').'-'.$counter;
+            $counter++;
+            $query = static::where('slug', $slug);
+            if ($id) {
+                $query->where('id', '!=', $id);
+            }
+        }
+
+        return $slug;
+    }
 
     /**
      * Get the user that owns the post.

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Post;
+
+class PostObserver
+{
+    /**
+     * Handle the Post "creating" event.
+     */
+    public function creating(Post $post): void
+    {
+        if (empty($post->slug)) {
+            $post->slug = Post::generateUniqueSlug($post->name);
+        }
+    }
+
+    /**
+     * Handle the Post "updating" event.
+     */
+    public function updating(Post $post): void
+    {
+        if ($post->isDirty('name') && empty($post->slug)) {
+            $post->slug = Post::generateUniqueSlug($post->name, $post->id);
+        }
+    }
+}

--- a/app/Observers/PostObserver.php
+++ b/app/Observers/PostObserver.php
@@ -3,16 +3,21 @@
 namespace App\Observers;
 
 use App\Models\Post;
+use App\Services\PostService;
 
 class PostObserver
 {
+    public function __construct(
+        private PostService $postService
+    ) {}
+
     /**
      * Handle the Post "creating" event.
      */
     public function creating(Post $post): void
     {
         if (empty($post->slug)) {
-            $post->slug = Post::generateUniqueSlug($post->name);
+            $post->slug = $this->postService->generateUniqueSlug($post->name);
         }
     }
 
@@ -22,7 +27,7 @@ class PostObserver
     public function updating(Post $post): void
     {
         if ($post->isDirty('name') && empty($post->slug)) {
-            $post->slug = Post::generateUniqueSlug($post->name, $post->id);
+            $post->slug = $this->postService->generateUniqueSlug($post->name, $post->id);
         }
     }
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Post $post): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Post $post): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Post $post): bool
+    {
+        return false;
+    }
+}

--- a/app/Services/PostService.php
+++ b/app/Services/PostService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use Illuminate\Support\Str;
+
+class PostService
+{
+    /**
+     * Generate a unique slug for a post.
+     */
+    public function generateUniqueSlug(string $name, ?int $excludeId = null): string
+    {
+        $baseSlug = Str::slug($name);
+        $slug = $baseSlug ?: 'untitled';
+        $counter = 1;
+
+        $query = Post::where('slug', $slug);
+        
+        if ($excludeId) {
+            $query->where('id', '!=', $excludeId);
+        }
+
+        while ($query->exists()) {
+            $slug = "{$baseSlug}-{$counter}";
+            $counter++;
+            $query = Post::where('slug', $slug);
+            
+            if ($excludeId) {
+                $query->where('id', '!=', $excludeId);
+            }
+        }
+
+        return $slug;
+    }
+}

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -16,9 +16,12 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
+        $name = fake()->sentence(3);
+
         return [
             'user_id' => \App\Models\User::factory(),
-            'name' => fake()->sentence(3),
+            'name' => $name,
+            'slug' => \Illuminate\Support\Str::slug($name),
             'content' => fake()->paragraphs(3, true),
             'category' => fake()->randomElement(['Technology', 'Business', 'Health', 'Travel', 'Food', 'Entertainment', 'Sports', 'Education']),
         ];

--- a/database/migrations/2025_09_05_055902_add_slug_to_posts_table.php
+++ b/database/migrations/2025_09_05_055902_add_slug_to_posts_table.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Models\Post;
+use App\Services\PostService;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -19,17 +19,10 @@ return new class extends Migration
         });
 
         // Populate slugs for existing posts
-        Post::whereNull('slug')->orWhere('slug', '')->chunkById(100, function ($posts) {
+        $postService = app(PostService::class);
+        Post::whereNull('slug')->orWhere('slug', '')->chunkById(100, function ($posts) use ($postService) {
             foreach ($posts as $post) {
-                $baseSlug = Str::slug($post->name);
-                $slug = $baseSlug;
-                $counter = 1;
-
-                while (Post::where('slug', $slug)->where('id', '!=', $post->id)->exists()) {
-                    $slug = "{$baseSlug}-{$counter}";
-                    $counter++;
-                }
-
+                $slug = $postService->generateUniqueSlug($post->name, $post->id);
                 $post->update(['slug' => $slug]);
             }
         });

--- a/database/migrations/2025_09_05_055902_add_slug_to_posts_table.php
+++ b/database/migrations/2025_09_05_055902_add_slug_to_posts_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Post;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // First add the column as nullable
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('slug')->nullable()->after('name');
+        });
+
+        // Populate slugs for existing posts
+        Post::whereNull('slug')->orWhere('slug', '')->chunkById(100, function ($posts) {
+            foreach ($posts as $post) {
+                $baseSlug = Str::slug($post->name);
+                $slug = $baseSlug;
+                $counter = 1;
+
+                while (Post::where('slug', $slug)->where('id', '!=', $post->id)->exists()) {
+                    $slug = "{$baseSlug}-{$counter}";
+                    $counter++;
+                }
+
+                $post->update(['slug' => $slug]);
+            }
+        });
+
+        // Now make the column required and unique
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->unique()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/resources/js/pages/posts/create.tsx
+++ b/resources/js/pages/posts/create.tsx
@@ -36,16 +36,6 @@ export default function CreatePost() {
         category: '',
     });
 
-    // Auto-generate slug from title when user leaves the title field
-    const handleTitleBlur = () => {
-        if (data.name && !data.slug) {
-            const generatedSlug = data.name
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, '-')
-                .replace(/^-+|-+$/g, '');
-            setData('slug', generatedSlug);
-        }
-    };
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -87,7 +77,6 @@ export default function CreatePost() {
                                         type="text"
                                         value={data.name}
                                         onChange={(e) => setData('name', e.target.value)}
-                                        onBlur={handleTitleBlur}
                                         placeholder="Enter post title..."
                                         aria-invalid={!!errors.name}
                                     />
@@ -95,19 +84,18 @@ export default function CreatePost() {
                                 </div>
 
                                 <div className="space-y-2">
-                                    <Label htmlFor="slug">Slug *</Label>
+                                    <Label htmlFor="slug">Slug</Label>
                                     <Input
                                         id="slug"
                                         type="text"
                                         value={data.slug}
                                         onChange={(e) => setData('slug', e.target.value)}
-                                        placeholder="URL slug (required)"
-                                        required
+                                        placeholder="URL slug (optional)"
                                         aria-invalid={!!errors.slug}
                                     />
                                     <InputError message={errors.slug} />
                                     <p className="text-sm text-muted-foreground">
-                                        Auto-generated when you finish typing the title
+                                        Leave empty to auto-generate from title
                                     </p>
                                 </div>
 

--- a/resources/js/pages/posts/create.tsx
+++ b/resources/js/pages/posts/create.tsx
@@ -23,6 +23,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 type PostForm = {
     name: string;
+    slug: string;
     content: string;
     category: string;
 };
@@ -30,9 +31,21 @@ type PostForm = {
 export default function CreatePost() {
     const { data, setData, post, errors, processing, reset } = useForm<PostForm>({
         name: '',
+        slug: '',
         content: '',
         category: '',
     });
+
+    // Auto-generate slug from title when user leaves the title field
+    const handleTitleBlur = () => {
+        if (data.name && !data.slug) {
+            const generatedSlug = data.name
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+            setData('slug', generatedSlug);
+        }
+    };
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -74,10 +87,28 @@ export default function CreatePost() {
                                         type="text"
                                         value={data.name}
                                         onChange={(e) => setData('name', e.target.value)}
+                                        onBlur={handleTitleBlur}
                                         placeholder="Enter post title..."
                                         aria-invalid={!!errors.name}
                                     />
                                     <InputError message={errors.name} />
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="slug">Slug *</Label>
+                                    <Input
+                                        id="slug"
+                                        type="text"
+                                        value={data.slug}
+                                        onChange={(e) => setData('slug', e.target.value)}
+                                        placeholder="URL slug (required)"
+                                        required
+                                        aria-invalid={!!errors.slug}
+                                    />
+                                    <InputError message={errors.slug} />
+                                    <p className="text-sm text-muted-foreground">
+                                        Auto-generated when you finish typing the title
+                                    </p>
                                 </div>
 
                                 <div className="space-y-2">

--- a/resources/js/pages/posts/edit.tsx
+++ b/resources/js/pages/posts/edit.tsx
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/app-layout';
 interface Post {
     id: number;
     name: string;
+    slug: string;
     content: string;
     category?: string;
     created_at: string;
@@ -30,6 +31,7 @@ interface EditPostProps {
 
 type PostForm = {
     name: string;
+    slug: string;
     content: string;
     category: string;
 };
@@ -42,11 +44,11 @@ export default function EditPost({ post }: EditPostProps) {
         },
         {
             title: post.name.length > 20 ? post.name.substring(0, 20) + '...' : post.name,
-            href: `/posts/${post.id}`,
+            href: `/posts/${post.slug}`,
         },
         {
             title: 'Edit',
-            href: `/posts/${post.id}/edit`,
+            href: `/posts/${post.slug}/edit`,
         },
     ];
 
@@ -59,6 +61,7 @@ export default function EditPost({ post }: EditPostProps) {
         processing,
     } = useForm<PostForm>({
         name: post.name,
+        slug: post.slug,
         content: post.content,
         category: post.category || '',
     });
@@ -66,12 +69,12 @@ export default function EditPost({ post }: EditPostProps) {
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
 
-        put(route('posts.update', post.id));
+        put(route('posts.update', post.slug));
     };
 
     const handleDelete = () => {
         if (confirm('Are you sure you want to delete this post? This action cannot be undone.')) {
-            destroy(route('posts.destroy', post.id));
+            destroy(route('posts.destroy', post.slug));
         }
     };
 
@@ -81,7 +84,7 @@ export default function EditPost({ post }: EditPostProps) {
 
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
                 <div className="flex items-center gap-4">
-                    <Link href={`/posts/${post.id}`}>
+                    <Link href={`/posts/${post.slug}`}>
                         <Button variant="outline" size="icon">
                             <ArrowLeft className="h-4 w-4" />
                         </Button>
@@ -118,6 +121,19 @@ export default function EditPost({ post }: EditPostProps) {
                                 </div>
 
                                 <div className="space-y-2">
+                                    <Label htmlFor="slug">Slug</Label>
+                                    <Input
+                                        id="slug"
+                                        type="text"
+                                        value={data.slug}
+                                        onChange={(e) => setData('slug', e.target.value)}
+                                        placeholder="URL slug"
+                                        aria-invalid={!!errors.slug}
+                                    />
+                                    <InputError message={errors.slug} />
+                                </div>
+
+                                <div className="space-y-2">
                                     <Label htmlFor="category">Category</Label>
                                     <Input
                                         id="category"
@@ -149,7 +165,7 @@ export default function EditPost({ post }: EditPostProps) {
                                         {processing ? 'Updating...' : 'Update Post'}
                                     </Button>
 
-                                    <Link href={`/posts/${post.id}`}>
+                                    <Link href={`/posts/${post.slug}`}>
                                         <Button type="button" variant="outline">
                                             Cancel
                                         </Button>

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,5 +1,5 @@
-import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/react';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
 import { Clock, Edit, Eye, MessageCircle, Plus, User } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -52,6 +52,8 @@ interface PostsPageProps {
 }
 
 export default function PostsIndex({ posts }: PostsPageProps) {
+    const { auth } = usePage<SharedData>().props;
+
     const formatDate = (dateString: string) => {
         return new Date(dateString).toLocaleDateString('en-US', {
             year: 'numeric',
@@ -159,11 +161,13 @@ export default function PostsIndex({ posts }: PostsPageProps) {
                                                             <Eye className="h-4 w-4" />
                                                         </Button>
                                                     </Link>
-                                                    <Link href={`/posts/${post.id}/edit`}>
-                                                        <Button variant="ghost" size="sm">
-                                                            <Edit className="h-4 w-4" />
-                                                        </Button>
-                                                    </Link>
+                                                    {auth.user.id === post.user.id && (
+                                                        <Link href={`/posts/${post.id}/edit`}>
+                                                            <Button variant="ghost" size="sm">
+                                                                <Edit className="h-4 w-4" />
+                                                            </Button>
+                                                        </Link>
+                                                    )}
                                                 </div>
                                             </TableCell>
                                         </TableRow>

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -17,6 +17,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 interface Post {
     id: number;
     name: string;
+    slug: string;
     content: string;
     category?: string;
     created_at: string;
@@ -119,7 +120,7 @@ export default function PostsIndex({ posts }: PostsPageProps) {
                                             <TableCell className="whitespace-normal">
                                                 <div>
                                                     <Link
-                                                        href={`/posts/${post.id}`}
+                                                        href={`/posts/${post.slug}`}
                                                         className="hover:text-primary block truncate font-medium transition-colors"
                                                         title={post.name}
                                                     >
@@ -156,13 +157,13 @@ export default function PostsIndex({ posts }: PostsPageProps) {
                                             </TableCell>
                                             <TableCell>
                                                 <div className="flex gap-1">
-                                                    <Link href={`/posts/${post.id}`}>
+                                                    <Link href={`/posts/${post.slug}`}>
                                                         <Button variant="ghost" size="sm">
                                                             <Eye className="h-4 w-4" />
                                                         </Button>
                                                     </Link>
                                                     {auth.user.id === post.user.id && (
-                                                        <Link href={`/posts/${post.id}/edit`}>
+                                                        <Link href={`/posts/${post.slug}/edit`}>
                                                             <Button variant="ghost" size="sm">
                                                                 <Edit className="h-4 w-4" />
                                                             </Button>

--- a/resources/js/pages/posts/index.tsx
+++ b/resources/js/pages/posts/index.tsx
@@ -1,5 +1,5 @@
 import { type BreadcrumbItem, type SharedData } from '@/types';
-import { Head, Link, router, usePage } from '@inertiajs/react';
+import { Head, Link, router, usePage, WhenVisible } from '@inertiajs/react';
 import { Clock, Edit, Eye, MessageCircle, Plus, Search, User, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -40,24 +40,17 @@ interface Post {
 }
 
 interface PostsPageProps {
-    posts: {
-        data: Post[];
-        current_page: number;
-        per_page: number;
-        total: number;
-        last_page: number;
-        links: Array<{
-            url: string | null;
-            label: string;
-            active: boolean;
-        }>;
-    };
+    posts: Post[];
     filters: {
         search: string;
     };
+    page: number;
+    nextPageExists: boolean;
+    total: number;
 }
 
-export default function PostsIndex({ posts, filters }: PostsPageProps) {
+
+export default function PostsIndex({ posts, filters, page, nextPageExists, total }: PostsPageProps) {
     const { auth } = usePage<SharedData>().props;
     const [search, setSearch] = useState(filters.search || '');
     const [isSearching, setIsSearching] = useState(false);
@@ -140,7 +133,7 @@ export default function PostsIndex({ posts, filters }: PostsPageProps) {
                     )}
                 </div>
 
-                {posts.data.length === 0 ? (
+                {posts.length === 0 ? (
                     <Card className="py-12 text-center">
                         <CardContent>
                             <div className="flex flex-col items-center gap-4">
@@ -179,7 +172,7 @@ export default function PostsIndex({ posts, filters }: PostsPageProps) {
                             {search && (
                                 <div className="border-b bg-muted/30 px-4 py-2">
                                     <p className="text-sm text-muted-foreground">
-                                        Found {posts.total} result{posts.total !== 1 ? 's' : ''} for "{search}"
+                                        Found {total} result{total !== 1 ? 's' : ''} for "{search}"
                                     </p>
                                 </div>
                             )}
@@ -195,7 +188,7 @@ export default function PostsIndex({ posts, filters }: PostsPageProps) {
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
-                                    {posts.data.map((post) => (
+                                    {posts.map((post) => (
                                         <TableRow key={post.id}>
                                             <TableCell className="whitespace-normal">
                                                 <div>
@@ -253,30 +246,23 @@ export default function PostsIndex({ posts, filters }: PostsPageProps) {
                                             </TableCell>
                                         </TableRow>
                                     ))}
+                                    {nextPageExists && (
+                                        <WhenVisible
+                                            always
+                                            params={{
+                                                data: {
+                                                    page: + page + 1,
+                                                },
+                                                only: ['posts', 'page', 'isNextPageExists'],
+                                            }}
+                                            fallback={<p>You reach the end.</p>}
+                                        >
+                                            <p>Loading...</p>
+                                        </WhenVisible>
+                                    )}
                                 </TableBody>
                             </Table>
                         </Card>
-
-                        {/* Pagination */}
-                        {posts.last_page > 1 && (
-                            <div className="flex items-center justify-center gap-2">
-                                {posts.links.map((link, index) => (
-                                    <span key={index}>
-                                        {link.url ? (
-                                            <Link href={link.url}>
-                                                <Button
-                                                    variant={link.active ? 'default' : 'outline'}
-                                                    size="sm"
-                                                    dangerouslySetInnerHTML={{ __html: link.label }}
-                                                />
-                                            </Link>
-                                        ) : (
-                                            <Button variant="outline" size="sm" disabled dangerouslySetInnerHTML={{ __html: link.label }} />
-                                        )}
-                                    </span>
-                                ))}
-                            </div>
-                        )}
                     </div>
                 )}
             </div>

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -23,6 +23,7 @@ interface Comment {
 interface Post {
     id: number;
     name: string;
+    slug: string;
     content: string;
     category?: string;
     created_at: string;
@@ -54,7 +55,7 @@ export default function ShowPost({ post }: PostShowProps) {
         },
         {
             title: post.name.length > 30 ? post.name.substring(0, 30) + '...' : post.name,
-            href: `/posts/${post.id}`,
+            href: `/posts/${post.slug}`,
         },
     ];
 
@@ -124,7 +125,7 @@ export default function ShowPost({ post }: PostShowProps) {
                     </div>
                     {isOwner && (
                         <div className="flex gap-2">
-                            <Link href={`/posts/${post.id}/edit`}>
+                            <Link href={`/posts/${post.slug}/edit`}>
                                 <Button variant="outline" size="sm">
                                     <Edit className="h-4 w-4" />
                                     Edit

--- a/tests/Feature/CommentControllerTest.php
+++ b/tests/Feature/CommentControllerTest.php
@@ -19,7 +19,7 @@ it('can store a new comment', function () {
 
     $response = $this->actingAs($this->user)->post('/comments', $commentData);
 
-    $response->assertRedirect("/posts/{$this->post->id}");
+    $response->assertRedirect("/posts/{$this->post->slug}");
     $this->assertDatabaseHas('comments', [
         'post_id' => $this->post->id,
         'content' => 'This is a test comment.',

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -34,6 +34,7 @@ it('can display post create page', function () {
 it('can store a new post', function () {
     $postData = [
         'name' => 'Test Post',
+        'slug' => 'test-post',
         'content' => 'This is test content for the post.',
         'category' => 'Technology',
     ];
@@ -43,6 +44,7 @@ it('can store a new post', function () {
     $response->assertRedirect();
     $this->assertDatabaseHas('posts', [
         'name' => 'Test Post',
+        'slug' => 'test-post',
         'content' => 'This is test content for the post.',
         'category' => 'Technology',
         'user_id' => $this->user->id,
@@ -52,13 +54,13 @@ it('can store a new post', function () {
 it('validates required fields when storing a post', function () {
     $response = $this->actingAs($this->user)->post('/posts', []);
 
-    $response->assertSessionHasErrors(['name', 'content']);
+    $response->assertSessionHasErrors(['name', 'slug', 'content']);
 });
 
 it('can display a single post', function () {
     $post = Post::factory()->create();
 
-    $response = $this->actingAs($this->user)->get("/posts/{$post->id}");
+    $response = $this->actingAs($this->user)->get("/posts/{$post->slug}");
 
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
@@ -70,7 +72,7 @@ it('can display a single post', function () {
 it('can display post edit page for owner', function () {
     $post = Post::factory()->create(['user_id' => $this->user->id]);
 
-    $response = $this->actingAs($this->user)->get("/posts/{$post->id}/edit");
+    $response = $this->actingAs($this->user)->get("/posts/{$post->slug}/edit");
 
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
@@ -83,13 +85,14 @@ it('can update a post as owner', function () {
     $post = Post::factory()->create(['user_id' => $this->user->id]);
     $updateData = [
         'name' => 'Updated Post Name',
+        'slug' => $post->slug,
         'content' => 'Updated post content.',
         'category' => 'Updated Category',
     ];
 
-    $response = $this->actingAs($this->user)->put("/posts/{$post->id}", $updateData);
+    $response = $this->actingAs($this->user)->put("/posts/{$post->slug}", $updateData);
 
-    $response->assertRedirect("/posts/{$post->id}");
+    $response->assertRedirect("/posts/{$post->slug}");
     $this->assertDatabaseHas('posts', [
         'id' => $post->id,
         'name' => 'Updated Post Name',
@@ -101,7 +104,7 @@ it('can update a post as owner', function () {
 it('can delete a post as owner', function () {
     $post = Post::factory()->create(['user_id' => $this->user->id]);
 
-    $response = $this->actingAs($this->user)->delete("/posts/{$post->id}");
+    $response = $this->actingAs($this->user)->delete("/posts/{$post->slug}");
 
     $response->assertRedirect('/posts');
     $this->assertDatabaseMissing('posts', ['id' => $post->id]);
@@ -111,7 +114,7 @@ it('cannot edit post that does not belong to user', function () {
     $otherUser = User::factory()->create();
     $post = Post::factory()->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($this->user)->get("/posts/{$post->id}/edit");
+    $response = $this->actingAs($this->user)->get("/posts/{$post->slug}/edit");
 
     $response->assertStatus(403);
 });
@@ -122,11 +125,12 @@ it('cannot update post that does not belong to user', function () {
 
     $updateData = [
         'name' => 'Hacked Post Name',
+        'slug' => 'hacked-slug',
         'content' => 'Hacked content.',
         'category' => 'Hacked Category',
     ];
 
-    $response = $this->actingAs($this->user)->put("/posts/{$post->id}", $updateData);
+    $response = $this->actingAs($this->user)->put("/posts/{$post->slug}", $updateData);
 
     $response->assertStatus(403);
     $this->assertDatabaseHas('posts', [
@@ -140,7 +144,7 @@ it('cannot delete post that does not belong to user', function () {
     $otherUser = User::factory()->create();
     $post = Post::factory()->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($this->user)->delete("/posts/{$post->id}");
+    $response = $this->actingAs($this->user)->delete("/posts/{$post->slug}");
 
     $response->assertStatus(403);
     $this->assertDatabaseHas('posts', ['id' => $post->id]);
@@ -152,25 +156,26 @@ it('requires authentication for all routes', function () {
     $this->get('/posts')->assertRedirect('/login');
     $this->get('/posts/create')->assertRedirect('/login');
     $this->post('/posts')->assertRedirect('/login');
-    $this->get("/posts/{$post->id}")->assertRedirect('/login');
-    $this->get("/posts/{$post->id}/edit")->assertRedirect('/login');
-    $this->put("/posts/{$post->id}")->assertRedirect('/login');
-    $this->delete("/posts/{$post->id}")->assertRedirect('/login');
+    $this->get("/posts/{$post->slug}")->assertRedirect('/login');
+    $this->get("/posts/{$post->slug}/edit")->assertRedirect('/login');
+    $this->put("/posts/{$post->slug}")->assertRedirect('/login');
+    $this->delete("/posts/{$post->slug}")->assertRedirect('/login');
 });
 
 it('validates post data using StorePostRequest', function () {
     $response = $this->actingAs($this->user)->post('/posts', [
         'name' => '',
+        'slug' => '',
         'content' => '',
     ]);
 
-    $response->assertSessionHasErrors(['name', 'content']);
+    $response->assertSessionHasErrors(['name', 'slug', 'content']);
 });
 
 it('validates post data using UpdatePostRequest', function () {
     $post = Post::factory()->create(['user_id' => $this->user->id]);
 
-    $response = $this->actingAs($this->user)->put("/posts/{$post->id}", [
+    $response = $this->actingAs($this->user)->put("/posts/{$post->slug}", [
         'name' => '',
         'content' => '',
     ]);
@@ -182,7 +187,7 @@ it('authorizes edit request via ShowPostEditRequest', function () {
     $otherUser = User::factory()->create();
     $post = Post::factory()->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($this->user)->get("/posts/{$post->id}/edit");
+    $response = $this->actingAs($this->user)->get("/posts/{$post->slug}/edit");
 
     $response->assertStatus(403);
 });
@@ -191,8 +196,9 @@ it('authorizes update request via UpdatePostRequest', function () {
     $otherUser = User::factory()->create();
     $post = Post::factory()->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($this->user)->put("/posts/{$post->id}", [
+    $response = $this->actingAs($this->user)->put("/posts/{$post->slug}", [
         'name' => 'Test',
+        'slug' => 'test-slug',
         'content' => 'Test content',
     ]);
 
@@ -203,7 +209,100 @@ it('authorizes delete request via DestroyPostRequest', function () {
     $otherUser = User::factory()->create();
     $post = Post::factory()->create(['user_id' => $otherUser->id]);
 
-    $response = $this->actingAs($this->user)->delete("/posts/{$post->id}");
+    $response = $this->actingAs($this->user)->delete("/posts/{$post->slug}");
 
     $response->assertStatus(403);
 });
+
+it('requires slug when creating post', function () {
+    $postData = [
+        'name' => 'Test Post Title',
+        'content' => 'This is test content for the post.',
+        'category' => 'Technology',
+    ];
+
+    $response = $this->actingAs($this->user)->post('/posts', $postData);
+
+    $response->assertSessionHasErrors(['slug']);
+});
+
+it('uses provided slug when creating post with slug', function () {
+    $postData = [
+        'name' => 'Test Post Title',
+        'slug' => 'custom-slug',
+        'content' => 'This is test content for the post.',
+        'category' => 'Technology',
+    ];
+
+    $response = $this->actingAs($this->user)->post('/posts', $postData);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('posts', [
+        'name' => 'Test Post Title',
+        'slug' => 'custom-slug',
+        'user_id' => $this->user->id,
+    ]);
+});
+
+it('validates slug uniqueness when creating post', function () {
+    Post::factory()->create(['slug' => 'duplicate-slug']);
+
+    $postData = [
+        'name' => 'Test Post Title',
+        'slug' => 'duplicate-slug',
+        'content' => 'This is test content for the post.',
+    ];
+
+    $response = $this->actingAs($this->user)->post('/posts', $postData);
+
+    $response->assertSessionHasErrors(['slug']);
+});
+
+it('can access post by slug', function () {
+    $post = Post::factory()->create(['slug' => 'test-slug']);
+
+    $response = $this->actingAs($this->user)->get('/posts/test-slug');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn ($page) => $page
+        ->component('posts/show')
+        ->has('post')
+        ->where('post.slug', 'test-slug')
+    );
+});
+
+it('can update post slug', function () {
+    $post = Post::factory()->create(['user_id' => $this->user->id, 'slug' => 'old-slug']);
+
+    $updateData = [
+        'name' => $post->name,
+        'slug' => 'new-slug',
+        'content' => $post->content,
+        'category' => $post->category,
+    ];
+
+    $response = $this->actingAs($this->user)->put('/posts/old-slug', $updateData);
+
+    $response->assertRedirect('/posts/new-slug');
+    $this->assertDatabaseHas('posts', [
+        'id' => $post->id,
+        'slug' => 'new-slug',
+    ]);
+});
+
+it('validates slug uniqueness when updating post', function () {
+    $existingPost = Post::factory()->create(['slug' => 'existing-slug']);
+    $postToUpdate = Post::factory()->create(['user_id' => $this->user->id, 'slug' => 'original-slug']);
+
+    $updateData = [
+        'name' => $postToUpdate->name,
+        'slug' => 'existing-slug',
+        'content' => $postToUpdate->content,
+        'category' => $postToUpdate->category,
+    ];
+
+    $response = $this->actingAs($this->user)->put('/posts/original-slug', $updateData);
+
+    $response->assertSessionHasErrors(['slug']);
+});
+

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -54,7 +54,28 @@ it('can store a new post', function () {
 it('validates required fields when storing a post', function () {
     $response = $this->actingAs($this->user)->post('/posts', []);
 
-    $response->assertSessionHasErrors(['name', 'slug', 'content']);
+    $response->assertSessionHasErrors(['name', 'content']);
+});
+
+it('can store a post without a slug', function () {
+    $postData = [
+        'name' => 'Test Post Without Slug',
+        'content' => 'This is test content for the post.',
+        'category' => 'Technology',
+    ];
+
+    $response = $this->actingAs($this->user)->post('/posts', $postData);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('posts', [
+        'name' => 'Test Post Without Slug',
+        'content' => 'This is test content for the post.',
+        'category' => 'Technology',
+        'user_id' => $this->user->id,
+    ]);
+    
+    $post = Post::where('name', 'Test Post Without Slug')->first();
+    expect($post->slug)->toEqual('test-post-without-slug');
 });
 
 it('can display a single post', function () {
@@ -169,7 +190,7 @@ it('validates post data using StorePostRequest', function () {
         'content' => '',
     ]);
 
-    $response->assertSessionHasErrors(['name', 'slug', 'content']);
+    $response->assertSessionHasErrors(['name', 'content']);
 });
 
 it('validates post data using UpdatePostRequest', function () {
@@ -214,17 +235,6 @@ it('authorizes delete request via DestroyPostRequest', function () {
     $response->assertStatus(403);
 });
 
-it('requires slug when creating post', function () {
-    $postData = [
-        'name' => 'Test Post Title',
-        'content' => 'This is test content for the post.',
-        'category' => 'Technology',
-    ];
-
-    $response = $this->actingAs($this->user)->post('/posts', $postData);
-
-    $response->assertSessionHasErrors(['slug']);
-});
 
 it('uses provided slug when creating post with slug', function () {
     $postData = [

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -18,7 +18,7 @@ it('can display posts index page', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 3)
+        ->has('posts', 3)
     );
 });
 
@@ -73,7 +73,7 @@ it('can store a post without a slug', function () {
         'category' => 'Technology',
         'user_id' => $this->user->id,
     ]);
-    
+
     $post = Post::where('name', 'Test Post Without Slug')->first();
     expect($post->slug)->toEqual('test-post-without-slug');
 });
@@ -326,8 +326,8 @@ it('can search posts by name', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 1)
-        ->where('posts.data.0.name', 'Laravel Tutorial')
+        ->has('posts', 1)
+        ->where('posts.0.name', 'Laravel Tutorial')
         ->where('filters.search', 'Laravel')
     );
 });
@@ -342,8 +342,8 @@ it('can search posts by content', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 1)
-        ->where('posts.data.0.name', 'Tutorial One')
+        ->has('posts', 1)
+        ->where('posts.0.name', 'Tutorial One')
         ->where('filters.search', 'React')
     );
 });
@@ -358,7 +358,7 @@ it('can search posts by category', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 2)
+        ->has('posts', 2)
         ->where('filters.search', 'Technology')
     );
 });
@@ -371,7 +371,7 @@ it('returns empty results for non-matching search', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 0)
+        ->has('posts', 0)
         ->where('filters.search', 'nonexistent')
     );
 });
@@ -384,7 +384,7 @@ it('returns all posts when search is empty', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 3)
+        ->has('posts', 3)
         ->where('filters.search', '')
     );
 });
@@ -403,9 +403,8 @@ it('maintains pagination with search results', function () {
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page
         ->component('posts/index')
-        ->has('posts.data', 10) // Should be limited to 10 per page
-        ->where('posts.total', 12)
-        ->where('posts.last_page', 2)
+        ->has('posts', 10) // Should be limited to 10 per page
+        ->where('total', 12)
         ->where('filters.search', 'Laravel')
     );
 });


### PR DESCRIPTION
### PR for the tech test submitted by Anthony Whitehead
- All tasks have been completed as set out in the requirements provided
- Each task has been PR'd separately and can be viewed here: https://github.com/antdwhitead/laravel-react-test/pulls?q=is%3Apr+is%3Aclosed

### Task 5 - Improvements going forward

## Backend
- Permissions to be handled by https://spatie.be/docs/laravel-permission/v6/introduction
- All controllers need to be refactored to be thin
   - Queries can be handled as scopes on models (this is in reference to the DashboardController)
   - Any business logic going forward can be broken out into a service (optional to use facade)
   - Validation and Authorisation should be handled by separate FormRequests
- Add PHPStan
- Implement parallel testing and update tests accordingly. Will help further down the line when there are 1000s of tests!
- CI/CD github pipeline
   - auto deploy on merge to main
   - restrict merge if tests/stan/pint fails
- Restrict lazy loading in appServiceProvider
- Declare strict types in all existing php files and enforce in new php files going forward
- Move from SQlite to MySql 
- Convert app to Sail for some docker containerisation goodness

 ## Front end
- Create reusable types to be used across components. For example there are currently 3 Post interfaces
- Pages can probably be broken down into more components
- CI/CD github pipeline
   - only allow merge if type check passes
- Use a third party component UI library for ease and consistency.



